### PR TITLE
Upgrade netatalk from 3.1.7 to 3.1.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:wheezy
 MAINTAINER cptactionhank <cptactionhank@users.noreply.github.com>
 
 ENV NETATALK_MAJOR 3.1
-ENV NETATALK_VERSION 3.1.7
+ENV NETATALK_VERSION 3.1.8
 
 COPY ./root /
 


### PR DESCRIPTION
Changes in 3.1.8

```
* FIX: CNID/MySQL: Quote UUID table names, bug #585
* FIX: Crash in cnid_metad, bug #593
* UPD: Update Unicode support to version 8.0.0
* FIX: larger server side copyfile buffer for improved IO performance,
       bug #599
* NEW: afpd: new option "ea = samba". Use Samba vfs_streams_xattr
       compatible xattrs which means adding a 0 byte at the end of
       xattrs.
* FIX: remove #541 workaround patch. There was this problem with only early
       Fedora 20.
* FIX: rpmbuild fails on Fedora x86_64, bug #598
* FIX: Listen on IPv6 wildcard address by default, bug #602
* FIX: FCE protocol version 1 packets, bug #603
* UPD: Update list of BerkeleyDB versions searched at configure time
```
