### PR TITLE
Disable avahi daemon by default, enable with docker run -e AVAHI=1, minor cleanup, don't rm locales

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ valid users = %USER%
 
 ### Service discovery
 
+This image includes an avahi daemon which is off by default. Enable by setting the environment variable `AVAHI=1` with `docker run -e AVAHI=1 ...`
+
 Service discovery works only when the [Avahi] daemon is on the same network as your users which is why you need to supply `--net=host` flag to Docker when creating the container, but do consider that `--net=host` is considered a security threat. Alternatively you can install and setup an mDNS server on the host and have this describing the AFP service for your container.
 
 ## Acknowledgments

--- a/start.sh
+++ b/start.sh
@@ -18,5 +18,9 @@ cat /etc/afp.conf
 echo ---end---afp.conf--
 mkdir /var/run/dbus
 dbus-daemon --system
-avahi-daemon -D
+if [ "${AVAHI}" == "1" ]; then
+    avahi-daemon -D
+else
+    echo "Skipping avahi daemon, enable with env variable AVAHI=1"
+fi;
 exec netatalk -d


### PR DESCRIPTION
Due to security concerns and that the most-common usage might not need service discovery,
I disabled the avahi daemon by default but it's still runnable by doing `docker run -e AVAHI=1 ...``

Also removed an unused env variable at the top of the Dockerfile and reinstated /usr/share/locale files as they might be needed for some charset settings
