### PR TITLE
Problem with starting image with new GID

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -6,6 +6,7 @@ if [ ! -z "${AFP_USER}" ]; then
     fi
     if [ ! -z "${AFP_GID}" ]; then
         cmd="$cmd --gid ${AFP_GID}"
+        groupadd --gid ${AFP_GID} ${AFP_USER}
     fi
     adduser $cmd --no-create-home --disabled-password --gecos '' "${AFP_USER}"
     if [ ! -z "${AFP_PASSWORD}" ]; then

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -28,6 +28,7 @@ echo ---end---afp.conf--
 mkdir /var/run/dbus
 dbus-daemon --system
 if [ "${AVAHI}" == "1" ]; then
+    sed -i '/rlimit-nproc/d' /etc/avahi/avahi-daemon.conf
     avahi-daemon -D
 else
     echo "Skipping avahi daemon, enable with env variable AVAHI=1"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -27,7 +27,7 @@ cat /etc/afp.conf
 echo ---end---afp.conf--
 
 mkdir -p /var/run/dbus
-rm -f /var/run/dbus.pid
+rm -f /var/run/dbus/pid
 dbus-daemon --system
 if [ "${AVAHI}" == "1" ]; then
     sed -i '/rlimit-nproc/d' /etc/avahi/avahi-daemon.conf

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -26,7 +26,8 @@ echo ---begin-afp.conf--
 cat /etc/afp.conf
 echo ---end---afp.conf--
 
-mkdir /var/run/dbus
+mkdir -p /var/run/dbus
+rm -f /var/run/dbus.pid
 dbus-daemon --system
 if [ "${AVAHI}" == "1" ]; then
     sed -i '/rlimit-nproc/d' /etc/avahi/avahi-daemon.conf


### PR DESCRIPTION
If AFP_GID is specified, create a group to avoid problems with the `useradd` command.
Fixes problem mentioned in #7.

The commit from @mattiash I can't comment on.
