### PR TITLE
Remove stale lock at startup if it exists

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -42,4 +42,6 @@ else
     echo "Skipping avahi daemon, enable with env variable AVAHI=1"
 fi;
 
+test -e /var/lock/netatalk && rm /var/lock/netatalk
+
 exec netatalk -d


### PR DESCRIPTION
If the netatalk does not finish gracefully, which has happened to me, a stale lock file will be left behind. This prevents re-starting the container. This change addresses that.